### PR TITLE
Remove attachments field from version struct

### DIFF
--- a/router.go
+++ b/router.go
@@ -116,6 +116,7 @@ func createVersion(c echo.Context) (err error) {
 		return err
 	}
 
+	// TODO: use registry.CreatePendingVersion instead
 	if err = registry.CreateVersion(getSpace(c), ver, attachments, app, editor); err != nil {
 		return err
 	}

--- a/router.go
+++ b/router.go
@@ -111,12 +111,12 @@ func createVersion(c echo.Context) (err error) {
 		return registry.ErrVersionAlreadyExists
 	}
 
-	ver, err := registry.DownloadVersion(opts)
+	ver, attachments, err := registry.DownloadVersion(opts)
 	if err != nil {
 		return err
 	}
 
-	if err = registry.CreatePendingVersion(getSpace(c), ver, app, editor); err != nil {
+	if err = registry.CreatePendingVersion(getSpace(c), ver, attachments, app, editor); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Make it clearer that attachments are not a part of the version struct and the field was just there to pass data around.