### PR TITLE
Attach latest version to application listing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: javascript
-env:
-  global:
-    secure: SmOt0/3p3CXg/98js9KyfGTmYRdgI61G3GlSC13Dtz6qTvkxvDrykNndCTOFhho/D5tQq6g0aQaQgu6X1145DTvO6sayjwnJiC/MYIJShikGsjfJK4yKFjdCKdumkZ56vv+LxzJKEx6o/6TbPvRRkblfN12bOMLE5SYs4wWb8T0TbY7YSXr3ep8Uz0FgGACBQhf6aunMoXmPcGbobJrTjSreb8mdLZ3LsseBFVbOp47AL53j9nyR+ZzP/wqED0Lys+T5oWG3C9Dt7vNet7cNpFIHYWYpC0ipgYeKdjeGB2LyQqSKRyQkT4bqu7fS2esWsbhSxWJVM7zJ9Ml5wA3FZ7xCtH1e8Q+4BYpbQYWoRqVe71StDeJxYssQ28KsbudIujLTxuB6Pc8DRUyCmaj9cr3811ZXs1V9jskb3Pux7BzwHZCUaELY/lbCJwEKzbpW2dJ0hQ5SYHBf/ZYt7OGPjZOWgntcAw2J2QUi/rxQ+CzZfcE6KBU27PeGVZjA7iSroXLB9mgdg0xnJAo7jNeprraWPZXMU6ZEZ5/6P4zjhxdgKfJqoKkekxVdSNwSyFaN1e+diq4Bfx9gcfPHlAFUzPyKjE8hjPAezqzPXWCuTS/gc90lRM+UiCShjIhKd8zanLr8crKs0K7tAZfHZibrYXpH76O3qh/qRHiiEXhnGZE=
-script:
-- 'curl -sS -X POST -d @app.json -H "Content-Type: application/json" -H "Authorization:
-  Token $REGISTRY_TOKEN" https://registry.cozy.io/registry'
-- 'version=$(curl -sS https://github.com/$TRAVIS_REPO_SLUG/archive/$TRAVIS_COMMIT.tar.gz | shasum -a 256 | cut -d" " -f1)'
-- 'echo $version'

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -216,10 +216,11 @@ func FindAppVersions(c *Space, appSlug string) (*AppVersions, error) {
 }
 
 type AppsListOptions struct {
-	Limit   int
-	Cursor  int
-	Sort    string
-	Filters map[string]string
+	Limit                int
+	Cursor               int
+	Sort                 string
+	Filters              map[string]string
+	LatestVersionChannel Channel
 }
 
 func GetPendingVersions(c *Space) ([]*Version, error) {
@@ -332,6 +333,10 @@ func GetAppsList(c *Space, opts *AppsListOptions) (int, []*App, error) {
 	for _, app := range res {
 		app.Versions, err = FindAppVersions(c, app.Slug)
 		if err != nil {
+			return 0, nil, err
+		}
+		app.LatestVersion, err = FindLatestVersion(c, app.Slug, opts.LatestVersionChannel)
+		if err != nil && err != ErrVersionNotFound {
 			return 0, nil, err
 		}
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -92,7 +92,7 @@ var (
 type Channel int
 
 const (
-	Stable Channel = iota
+	Stable Channel = iota + 1
 	Beta
 	Dev
 )
@@ -147,6 +147,8 @@ type App struct {
 	Editor    string       `json:"editor"`
 	CreatedAt time.Time    `json:"created_at"`
 	Versions  *AppVersions `json:"versions,omitempty"`
+
+	LatestVersion *Version `json:"latest_version,omitempty"`
 }
 
 type Locales map[string]interface{}


### PR DESCRIPTION
To avoid N+1 requests issue on application listing, we attach the latest version (from a configurable channel) with the application metadata in a `latest_version` field.