### PR TITLE
Fix registry for kivik upstream

### DIFF
--- a/registry/export.go
+++ b/registry/export.go
@@ -122,7 +122,7 @@ func writeDocs(db *kivik.DB, tw *tar.Writer) error {
 }
 
 func writeAttachment(db *kivik.DB, tw *tar.Writer, dbName, docID, filename string) error {
-	att, err := db.GetAttachment(ctx, docID, "", filename)
+	att, err := db.GetAttachment(ctx, docID, filename)
 	if err != nil {
 		return err
 	}
@@ -198,14 +198,15 @@ func Import(in io.Reader) (err error) {
 			return
 		}
 		if !ok {
-			if _, err = client.CreateDB(ctx, dbName); err != nil {
+			db := client.CreateDB(ctx, dbName)
+			if err = db.Err(); err != nil {
 				return
 			}
 		}
 
 		var db *kivik.DB
-		db, err = client.DB(ctx, dbName)
-		if err != nil {
+		db = client.DB(ctx, dbName)
+		if err = db.Err(); err != nil {
 			return
 		}
 

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -132,7 +132,7 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 func FindVersionOldAttachment(c *Space, appSlug, version, filename string) (*kivik.Attachment, error) {
 	db := c.VersDB()
 
-	att, err := db.GetAttachment(ctx, getVersionID(appSlug, version), "", filename)
+	att, err := db.GetAttachment(ctx, getVersionID(appSlug, version), filename)
 	if err != nil {
 		if kivik.StatusCode(err) == http.StatusNotFound {
 			return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("Could not find attachment %q", filename))

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -314,14 +314,15 @@ func InitGlobalClient(addr, user, pass, prefix string) (editorsDB *kivik.DB, err
 	}
 	if !exists {
 		fmt.Printf("Creating database %q...", editorsDBName)
-		if _, err = client.CreateDB(ctx, editorsDBName); err != nil {
+		db := client.CreateDB(ctx, editorsDBName)
+		if err = db.Err(); err != nil {
 			return
 		}
 		fmt.Println("ok.")
 	}
 
-	globalEditorsDB, err = client.DB(ctx, editorsDBName)
-	if err != nil {
+	globalEditorsDB = client.DB(ctx, editorsDBName)
+	if err = globalEditorsDB.Err(); err != nil {
 		return
 	}
 
@@ -372,15 +373,16 @@ func (c *Space) init() (err error) {
 		}
 		if !ok {
 			fmt.Printf("Creating database %q...", dbName)
-			if _, err = client.CreateDB(ctx, dbName); err != nil {
+			db := client.CreateDB(ctx, dbName)
+			if err = db.Err(); err != nil {
 				fmt.Println("failed")
 				return err
 			}
 			fmt.Println("ok.")
 		}
 		var db *kivik.DB
-		db, err = client.DB(context.Background(), dbName)
-		if err != nil {
+		db = client.DB(context.Background(), dbName)
+		if err = db.Err(); err != nil {
 			return
 		}
 		switch suffix {
@@ -628,7 +630,7 @@ func ApprovePendingVersion(c *Space, pending *Version, app *App) (*Version, erro
 
 	var attachments []*kivik.Attachment
 	for filename := range release.Attachments {
-		attachment, err := db.GetAttachment(ctx, pending.ID, pending.Rev, filename)
+		attachment, err := db.GetAttachment(ctx, pending.ID, filename)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- rev argument is not mandatory anymore for Attachment functions
- err is wrapped in DB structure