### PR TITLE
Fix screenshot path during app publication

### DIFF
--- a/registry/export.go
+++ b/registry/export.go
@@ -198,9 +198,8 @@ func Import(in io.Reader) (err error) {
 			return
 		}
 		if !ok {
-			db := client.CreateDB(ctx, dbName)
-			if err = db.Err(); err != nil {
-				return
+			if err := client.CreateDB(ctx, dbName); err != nil {
+				return err
 			}
 		}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1012,7 +1012,7 @@ func downloadVersion(opts *VersionOptions) (ver *Version, attachments []*kivik.A
 				if isIcon {
 					filename = "icon"
 				} else if isShot {
-					filename = name
+					filename = path.Join("screenshots", name)
 				} else if isPartnershipIcon {
 					filename = "partnership_icon"
 				} else {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -317,9 +317,8 @@ func InitGlobalClient(addr, user, pass, prefix string) (editorsDB *kivik.DB, err
 	}
 	if !exists {
 		fmt.Printf("Creating database %q...", editorsDBName)
-		db := client.CreateDB(ctx, editorsDBName)
-		if err = db.Err(); err != nil {
-			return
+		if err = client.CreateDB(ctx, editorsDBName); err != nil {
+			return nil, err
 		}
 		fmt.Println("ok.")
 	}
@@ -376,8 +375,7 @@ func (c *Space) init() (err error) {
 		}
 		if !ok {
 			fmt.Printf("Creating database %q...", dbName)
-			db := client.CreateDB(ctx, dbName)
-			if err = db.Err(); err != nil {
+			if err = client.CreateDB(ctx, dbName); err != nil {
 				fmt.Println("failed")
 				return err
 			}


### PR DESCRIPTION
This fix reverts the bug introduced in https://github.com/cozy/cozy-apps-registry/pull/28/files#diff-55e333416ad33b237c440cbd78d81cebL958

For new published versions, the screenshot path is missing, resulting in a shorter written filepath and inaccessible screenshot. 