### PR TITLE
Add a global asset store

### DIFF
--- a/asset/common.go
+++ b/asset/common.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"path/filepath"
+
+	"github.com/cozy/cozy-apps-registry/consts"
 
 	"github.com/cozy/cozy-apps-registry/config"
 	"github.com/go-kivik/couchdb/chttp"
@@ -97,4 +100,12 @@ func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
 	}
 
 	return globalAssetStoreDB, nil
+}
+
+// MarshalAssetKey returns the string key store in UsedBy field for app versions
+func MarshalAssetKey(spacePrefix, appSlug, version string) string {
+	if spacePrefix == consts.DefaultSpacePrefix {
+		spacePrefix = ""
+	}
+	return filepath.Join(spacePrefix, appSlug, version)
 }

--- a/asset/common.go
+++ b/asset/common.go
@@ -31,6 +31,7 @@ var ctx context.Context = context.Background()
 var globalAssetStoreDB *kivik.DB
 
 const assetStoreDBSuffix string = "assets"
+const AssetContainerName string = "__assets__"
 
 // InitGlobalAssetStore initializes the global asset store database
 func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
@@ -91,7 +92,7 @@ func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
 	conf, err := config.GetConfig()
 	sc := conf.SwiftConnection
 
-	if err := sc.ContainerCreate(assetContainerName, nil); err != nil {
+	if err := sc.ContainerCreate(AssetContainerName, nil); err != nil {
 		return nil, err
 	}
 

--- a/asset/common.go
+++ b/asset/common.go
@@ -116,10 +116,7 @@ func InitCouchDB(addr, user, pass, prefix string) (*kivik.DB, error) {
 }
 
 func InitSwift() (*swift.Connection, error) {
-	conf, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
+	conf := config.GetConfig()
 	sc := conf.SwiftConnection
 
 	if err := sc.ContainerCreate(AssetContainerName, nil); err != nil {

--- a/asset/common.go
+++ b/asset/common.go
@@ -159,9 +159,6 @@ func (a *GlobalAssetStore) AddAsset(asset *GlobalAsset, content io.Reader, sourc
 	}
 	if doc.Rev == "" {
 		_, _, err = AssetStore.DB.CreateDoc(ctx, doc)
-		if err != nil {
-			return err
-		}
 	} else {
 		_, err = AssetStore.DB.Put(ctx, doc.ID, doc, nil)
 	}

--- a/asset/common.go
+++ b/asset/common.go
@@ -179,7 +179,7 @@ func (a *GlobalAssetStore) RemoveAsset(md5, source string) error {
 		return err
 	}
 
-	var updatedVersions []string
+	updatedVersions := assetDoc.UsedBy[:0]
 	for _, versionfp := range assetDoc.UsedBy {
 		if versionfp == source {
 			continue

--- a/asset/common.go
+++ b/asset/common.go
@@ -1,0 +1,99 @@
+package asset
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/cozy/cozy-apps-registry/config"
+	"github.com/go-kivik/couchdb/chttp"
+	"github.com/go-kivik/kivik"
+)
+
+type AssetStorage interface {
+	New(*GlobalAsset) error
+	StoreAsset()
+	GetAsset()
+}
+
+type GlobalAsset struct {
+	ID          string   `json:"_id,omitempty"`
+	Rev         string   `json:"_rev,omitempty"`
+	Name        string   `json:"name"`
+	MD5         string   `json:"md5"`
+	AppSlug     string   `json:"appslug,omitempty"`
+	ContentType string   `json:"content_type"`
+	UsedBy      []string `json:"used_by"`
+}
+
+var client *kivik.Client
+var ctx context.Context = context.Background()
+var globalAssetStoreDB *kivik.DB
+
+const assetStoreDBSuffix string = "assets"
+
+// InitGlobalAssetStore initializes the global asset store database
+func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+	u.User = nil
+
+	client, err = kivik.New("couch", u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if user != "" {
+		err = client.Authenticate(ctx, &chttp.BasicAuth{
+			Username: user,
+			Password: pass,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	assetsStoreDBName := "registry-" + assetStoreDBSuffix
+	exists, err := client.DBExists(ctx, assetsStoreDBName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		fmt.Printf("Creating database %q...", assetsStoreDBName)
+		db := client.CreateDB(ctx, assetsStoreDBName)
+		if err = db.Err(); err != nil {
+			return nil, err
+		}
+		fmt.Println("ok.")
+	}
+
+	globalAssetStoreDB = client.DB(ctx, assetsStoreDBName)
+	if err = globalAssetStoreDB.Err(); err != nil {
+		return nil, err
+	}
+
+	// Create view for assetsDB
+	_, err = globalAssetStoreDB.Put(context.Background(), "_design/by-md5", map[string]interface{}{
+		"_id": "_design/by-md5",
+		"views": map[string]interface{}{
+			"by-md5": map[string]interface{}{
+				"map": "function (doc) { emit(doc.md5); }",
+			},
+		},
+	})
+	if err != nil && kivik.StatusCode(err) != 409 { // Ignore conflicts
+		return nil, err
+	}
+
+	// Create swift container for asset
+	conf, err := config.GetConfig()
+	sc := conf.SwiftConnection
+
+	if err := sc.ContainerCreate(assetContainerName, nil); err != nil {
+		return nil, err
+	}
+
+	return globalAssetStoreDB, nil
+}

--- a/asset/common.go
+++ b/asset/common.go
@@ -195,12 +195,12 @@ func (a *GlobalAssetStore) RemoveAsset(md5, source string) error {
 		return err
 	}
 
-	// Removing asset from the DB and the FS
-	err = AssetStore.FS.RemoveAsset(md5)
+	// First, removing from CouchDB
+	_, err = AssetStore.DB.Delete(ctx, md5, assetDoc.Rev)
 	if err != nil {
 		return err
 	}
-	_, err = AssetStore.DB.Delete(ctx, md5, assetDoc.Rev)
-	return err
 
+	// Then, removing the asset from the FS
+	return AssetStore.FS.RemoveAsset(md5)
 }

--- a/asset/common.go
+++ b/asset/common.go
@@ -1,23 +1,20 @@
 package asset
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"path/filepath"
 
-	"github.com/cozy/cozy-apps-registry/consts"
-
 	"github.com/cozy/cozy-apps-registry/config"
+	"github.com/cozy/cozy-apps-registry/consts"
+	"github.com/cozy/swift"
+
 	"github.com/go-kivik/couchdb/chttp"
 	"github.com/go-kivik/kivik"
 )
-
-type AssetStorage interface {
-	New(*GlobalAsset) error
-	StoreAsset()
-	GetAsset()
-}
 
 type GlobalAsset struct {
 	ID          string   `json:"_id,omitempty"`
@@ -31,13 +28,51 @@ type GlobalAsset struct {
 
 var client *kivik.Client
 var ctx context.Context = context.Background()
-var globalAssetStoreDB *kivik.DB
+var AssetStore *GlobalAssetStore
 
 const assetStoreDBSuffix string = "assets"
 const AssetContainerName string = "__assets__"
 
+type AssetStorage interface {
+	AddAsset(*GlobalAsset, io.Reader) error
+	GetAsset(string) (*bytes.Buffer, map[string]string, error)
+	RemoveAsset(string) error
+}
+
+type GlobalAssetStore struct {
+	FS AssetStorage
+	DB *kivik.DB
+}
+
 // InitGlobalAssetStore initializes the global asset store database
-func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
+func InitGlobalAssetStore(addr, user, pass, prefix string) (*GlobalAssetStore, error) {
+	globalAssetDB, err := InitCouchDB(addr, user, pass, prefix)
+	if err != nil {
+		return nil, err
+	}
+	sc, err := InitSwift()
+	if err != nil {
+		return nil, err
+	}
+	AssetStore = &GlobalAssetStore{
+		DB: globalAssetDB,
+		FS: &SwiftFS{Connection: sc},
+	}
+	if err != nil {
+		return nil, err
+	}
+	return AssetStore, nil
+}
+
+// MarshalAssetKey returns the string key store in UsedBy field for app versions
+func MarshalAssetKey(spacePrefix, appSlug, version string) string {
+	if spacePrefix == consts.DefaultSpacePrefix {
+		spacePrefix = ""
+	}
+	return filepath.Join(spacePrefix, appSlug, version)
+}
+
+func InitCouchDB(addr, user, pass, prefix string) (*kivik.DB, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -73,39 +108,101 @@ func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
 		fmt.Println("ok.")
 	}
 
-	globalAssetStoreDB = client.DB(ctx, assetsStoreDBName)
+	globalAssetStoreDB := client.DB(ctx, assetsStoreDBName)
 	if err = globalAssetStoreDB.Err(); err != nil {
-		return nil, err
-	}
-
-	// Create view for assetsDB
-	_, err = globalAssetStoreDB.Put(context.Background(), "_design/by-md5", map[string]interface{}{
-		"_id": "_design/by-md5",
-		"views": map[string]interface{}{
-			"by-md5": map[string]interface{}{
-				"map": "function (doc) { emit(doc.md5); }",
-			},
-		},
-	})
-	if err != nil && kivik.StatusCode(err) != 409 { // Ignore conflicts
-		return nil, err
-	}
-
-	// Create swift container for asset
-	conf, err := config.GetConfig()
-	sc := conf.SwiftConnection
-
-	if err := sc.ContainerCreate(AssetContainerName, nil); err != nil {
 		return nil, err
 	}
 
 	return globalAssetStoreDB, nil
 }
 
-// MarshalAssetKey returns the string key store in UsedBy field for app versions
-func MarshalAssetKey(spacePrefix, appSlug, version string) string {
-	if spacePrefix == consts.DefaultSpacePrefix {
-		spacePrefix = ""
+func InitSwift() (*swift.Connection, error) {
+	conf, err := config.GetConfig()
+	if err != nil {
+		return nil, err
 	}
-	return filepath.Join(spacePrefix, appSlug, version)
+	sc := conf.SwiftConnection
+
+	if err := sc.ContainerCreate(AssetContainerName, nil); err != nil {
+		return nil, err
+	}
+	return sc, nil
+}
+
+func (a *GlobalAssetStore) AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
+	// Creating the asset in the FS
+	err := a.FS.AddAsset(asset, content)
+	if err != nil {
+		return err
+	}
+
+	// Handles the CouchDB updates
+	var doc *GlobalAsset
+	row := AssetStore.DB.Get(ctx, asset.MD5, nil)
+	err = row.ScanDoc(&doc)
+	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
+		return err
+	}
+
+	var docRev string
+	// If asset does not exist in CouchDB global asset database, create it
+	if kivik.StatusCode(err) == kivik.StatusNotFound {
+		doc = asset
+		doc.ID = asset.MD5
+		_, docRev, err = AssetStore.DB.CreateDoc(ctx, doc)
+		if err != nil {
+			return err
+		}
+		doc.Rev = docRev
+	}
+
+	// Updating the UsedBy field to add the new app version
+	found := false
+	for _, usedBy := range doc.UsedBy {
+		if usedBy == source {
+			found = true
+			break
+		}
+	}
+	if !found {
+		doc.UsedBy = append(doc.UsedBy, source)
+	}
+	_, err = AssetStore.DB.Put(ctx, doc.ID, doc, nil)
+	return err
+}
+
+func (a *GlobalAssetStore) RemoveAsset(md5, versionFilepath string) error {
+	row := AssetStore.DB.Get(ctx, md5)
+
+	var assetDoc *GlobalAsset
+	err := row.ScanDoc(&assetDoc)
+	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
+		return err
+	}
+
+	var updatedVersions []string
+	for _, versionfp := range assetDoc.UsedBy {
+		if versionfp == versionFilepath {
+			continue
+		}
+		updatedVersions = append(updatedVersions, versionfp)
+	}
+
+	if len(updatedVersions) > 0 {
+		assetDoc.UsedBy = updatedVersions
+		_, err := AssetStore.DB.Put(ctx, md5, assetDoc)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Removing asset from the DB and the FS
+		err := AssetStore.FS.RemoveAsset(md5)
+		if err != nil {
+			return err
+		}
+		_, err = AssetStore.DB.Delete(ctx, md5, assetDoc.Rev)
+		return err
+	}
+
+	return nil
 }

--- a/asset/common.go
+++ b/asset/common.go
@@ -170,18 +170,18 @@ func (a *GlobalAssetStore) AddAsset(asset *GlobalAsset, content io.Reader, sourc
 	return err
 }
 
-func (a *GlobalAssetStore) RemoveAsset(md5, versionFilepath string) error {
+func (a *GlobalAssetStore) RemoveAsset(md5, source string) error {
 	row := AssetStore.DB.Get(ctx, md5)
 
 	var assetDoc *GlobalAsset
 	err := row.ScanDoc(&assetDoc)
-	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
+	if err != nil {
 		return err
 	}
 
 	var updatedVersions []string
 	for _, versionfp := range assetDoc.UsedBy {
-		if versionfp == versionFilepath {
+		if versionfp == source {
 			continue
 		}
 		updatedVersions = append(updatedVersions, versionfp)

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -1,0 +1,86 @@
+package asset
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/go-kivik/kivik"
+
+	"github.com/cozy/cozy-apps-registry/config"
+	"github.com/cozy/swift"
+)
+
+const assetContainerName string = "__assets__"
+
+func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
+
+	// Add to swift
+	conf, err := config.GetConfig()
+	sc := conf.SwiftConnection
+
+	// Creating object to swift
+	f, err := sc.ObjectCreate(assetContainerName, asset.MD5, true, asset.MD5, asset.ContentType, nil)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, content)
+	if err != nil {
+		return err
+	}
+
+	// CouchDB
+	var doc *GlobalAsset
+	row := globalAssetStoreDB.Get(context.Background(), asset.MD5, nil)
+	err = row.ScanDoc(&doc)
+	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
+		return err
+	}
+
+	var docRev string
+	// If asset does not exist, create it
+	if kivik.StatusCode(err) == kivik.StatusNotFound {
+		doc = asset
+		doc.ID = asset.MD5
+		_, docRev, err = globalAssetStoreDB.CreateDoc(context.Background(), doc)
+		if err != nil {
+			return err
+		}
+		doc.Rev = docRev
+	}
+
+	// Update it
+	found := false
+	for _, usedBy := range doc.UsedBy {
+		if usedBy == source {
+			found = true
+			break
+		}
+	}
+	if !found {
+		doc.UsedBy = append(doc.UsedBy, source)
+	}
+	_, err = globalAssetStoreDB.Put(context.Background(), doc.ID, doc, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func GetAsset(md5 string) (*bytes.Buffer, swift.Headers, error) {
+	conf, err := config.GetConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	buf := new(bytes.Buffer)
+	sc := conf.SwiftConnection
+	headers, err := sc.ObjectGet(assetContainerName, md5, buf, false, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return buf, headers, nil
+}

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -14,7 +14,7 @@ type SwiftFS struct {
 func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 	// Creating object to swift
 	sc := s.Connection
-	f, err := sc.ObjectCreate(AssetContainerName, asset.MD5, true, asset.MD5, asset.ContentType, nil)
+	f, err := sc.ObjectCreate(AssetContainerName, asset.Shasum, false, "", asset.ContentType, nil)
 	if err != nil {
 		return err
 	}
@@ -25,10 +25,10 @@ func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 
 }
 
-func (s *SwiftFS) GetAsset(md5 string) (*bytes.Buffer, map[string]string, error) {
+func (s *SwiftFS) GetAsset(shasum string) (*bytes.Buffer, map[string]string, error) {
 	sc := s.Connection
 	buf := new(bytes.Buffer)
-	headers, err := sc.ObjectGet(AssetContainerName, md5, buf, false, nil)
+	headers, err := sc.ObjectGet(AssetContainerName, shasum, buf, false, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,14 +36,14 @@ func (s *SwiftFS) GetAsset(md5 string) (*bytes.Buffer, map[string]string, error)
 }
 
 // Remove asset cleans a UsedByEntry and deletes the asset is there are no more app using the asset
-func (s *SwiftFS) RemoveAsset(md5 string) error {
+func (s *SwiftFS) RemoveAsset(shasum string) error {
 	// No more app is using the asset, we are going to clean it from couch
 	// and swift
 	sc := s.Connection
 
 	// Deleting the object from swift. If the object is not found, we should
 	// not crash
-	err := sc.ObjectDelete(AssetContainerName, md5)
+	err := sc.ObjectDelete(AssetContainerName, shasum)
 	if err != nil && err != swift.ObjectNotFound {
 		return err
 	}

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -2,8 +2,6 @@ package asset
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/hex"
 	"io"
 	"io/ioutil"
 
@@ -23,15 +21,7 @@ func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 		return err
 	}
 
-	// Calculating md5sum for swift insertion
-	md5sum := md5.New()
-	_, err = md5sum.Write(buf)
-	if err != nil {
-		return err
-	}
-	sum := md5sum.Sum(nil)
-
-	f, err := sc.ObjectCreate(AssetContainerName, asset.Shasum, true, hex.EncodeToString(sum), asset.ContentType, nil)
+	f, err := sc.ObjectCreate(AssetContainerName, asset.Shasum, true, "", asset.ContentType, nil)
 	if err != nil {
 		return err
 	}

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -2,7 +2,6 @@ package asset
 
 import (
 	"bytes"
-	"context"
 	"io"
 
 	"github.com/go-kivik/kivik"
@@ -10,8 +9,6 @@ import (
 	"github.com/cozy/cozy-apps-registry/config"
 	"github.com/cozy/swift"
 )
-
-const assetContainerName string = "__assets__"
 
 func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 
@@ -33,7 +30,7 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 
 	// CouchDB
 	var doc *GlobalAsset
-	row := globalAssetStoreDB.Get(context.Background(), asset.MD5, nil)
+	row := globalAssetStoreDB.Get(ctx, asset.MD5, nil)
 	err = row.ScanDoc(&doc)
 	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
 		return err
@@ -44,14 +41,14 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 	if kivik.StatusCode(err) == kivik.StatusNotFound {
 		doc = asset
 		doc.ID = asset.MD5
-		_, docRev, err = globalAssetStoreDB.CreateDoc(context.Background(), doc)
+		_, docRev, err = globalAssetStoreDB.CreateDoc(ctx, doc)
 		if err != nil {
 			return err
 		}
 		doc.Rev = docRev
 	}
 
-	// Update it
+	// Updating the UsedBy field to add the new app version
 	found := false
 	for _, usedBy := range doc.UsedBy {
 		if usedBy == source {
@@ -62,7 +59,7 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 	if !found {
 		doc.UsedBy = append(doc.UsedBy, source)
 	}
-	_, err = globalAssetStoreDB.Put(context.Background(), doc.ID, doc, nil)
+	_, err = globalAssetStoreDB.Put(ctx, doc.ID, doc, nil)
 	if err != nil {
 		return err
 	}
@@ -78,9 +75,56 @@ func GetAsset(md5 string) (*bytes.Buffer, swift.Headers, error) {
 	}
 	buf := new(bytes.Buffer)
 	sc := conf.SwiftConnection
-	headers, err := sc.ObjectGet(assetContainerName, md5, buf, false, nil)
+	headers, err := sc.ObjectGet(AssetContainerName, md5, buf, false, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	return buf, headers, nil
+}
+
+// Remove asset cleans a UsedByEntry and deletes the asset is there are no more app using the asset
+func RemoveAsset(md5, versionFilepath string) error {
+	row := globalAssetStoreDB.Get(ctx, md5)
+
+	var assetDoc *GlobalAsset
+	err := row.ScanDoc(&assetDoc)
+	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
+		return err
+	}
+
+	var updatedVersions []string
+	for _, versionfp := range assetDoc.UsedBy {
+		if versionfp == versionFilepath {
+			continue
+		}
+		updatedVersions = append(updatedVersions, versionfp)
+	}
+
+	if len(updatedVersions) > 0 {
+		assetDoc.UsedBy = updatedVersions
+		_, err := globalAssetStoreDB.Put(ctx, md5, assetDoc)
+		if err != nil {
+			return err
+		}
+	} else {
+		// No more app is using the asset, we are going to clean it from couch
+		// and swift
+		conf, err := config.GetConfig()
+		if err != nil {
+			return err
+		}
+		sc := conf.SwiftConnection
+
+		// Deleting the object from swift. If the object is not found, we should
+		// not crash
+		err = sc.ObjectDelete(AssetContainerName, md5)
+		if err != nil && err != swift.ObjectNotFound {
+			return err
+		}
+
+		_, err = globalAssetStoreDB.Delete(ctx, md5, assetDoc.Rev)
+		return err
+	}
+
+	return nil
 }

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -20,7 +20,7 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 	sc := conf.SwiftConnection
 
 	// Creating object to swift
-	f, err := sc.ObjectCreate(assetContainerName, asset.MD5, true, asset.MD5, asset.ContentType, nil)
+	f, err := sc.ObjectCreate(AssetContainerName, asset.MD5, true, asset.MD5, asset.ContentType, nil)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 	}
 
 	var docRev string
-	// If asset does not exist, create it
+	// If asset does not exist in CouchDB global asset database, create it
 	if kivik.StatusCode(err) == kivik.StatusNotFound {
 		doc = asset
 		doc.ID = asset.MD5

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -25,7 +25,10 @@ func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 
 	// Calculating md5sum for swift insertion
 	md5sum := md5.New()
-	md5sum.Write(buf)
+	_, err = md5sum.Write(buf)
+	if err != nil {
+		return err
+	}
 	sum := md5sum.Sum(nil)
 
 	f, err := sc.ObjectCreate(AssetContainerName, asset.Shasum, true, hex.EncodeToString(sum), asset.ContentType, nil)

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -21,11 +21,7 @@ func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 	defer f.Close()
 
 	_, err = io.Copy(f, content)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 
 }
 

--- a/asset/swift.go
+++ b/asset/swift.go
@@ -4,19 +4,16 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/go-kivik/kivik"
-
-	"github.com/cozy/cozy-apps-registry/config"
 	"github.com/cozy/swift"
 )
 
-func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
+type SwiftFS struct {
+	Connection *swift.Connection
+}
 
-	// Add to swift
-	conf, err := config.GetConfig()
-	sc := conf.SwiftConnection
-
+func (s *SwiftFS) AddAsset(asset *GlobalAsset, content io.Reader) error {
 	// Creating object to swift
+	sc := s.Connection
 	f, err := sc.ObjectCreate(AssetContainerName, asset.MD5, true, asset.MD5, asset.ContentType, nil)
 	if err != nil {
 		return err
@@ -28,53 +25,13 @@ func AddAsset(asset *GlobalAsset, content io.Reader, source string) error {
 		return err
 	}
 
-	// CouchDB
-	var doc *GlobalAsset
-	row := globalAssetStoreDB.Get(ctx, asset.MD5, nil)
-	err = row.ScanDoc(&doc)
-	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
-		return err
-	}
-
-	var docRev string
-	// If asset does not exist in CouchDB global asset database, create it
-	if kivik.StatusCode(err) == kivik.StatusNotFound {
-		doc = asset
-		doc.ID = asset.MD5
-		_, docRev, err = globalAssetStoreDB.CreateDoc(ctx, doc)
-		if err != nil {
-			return err
-		}
-		doc.Rev = docRev
-	}
-
-	// Updating the UsedBy field to add the new app version
-	found := false
-	for _, usedBy := range doc.UsedBy {
-		if usedBy == source {
-			found = true
-			break
-		}
-	}
-	if !found {
-		doc.UsedBy = append(doc.UsedBy, source)
-	}
-	_, err = globalAssetStoreDB.Put(ctx, doc.ID, doc, nil)
-	if err != nil {
-		return err
-	}
-
 	return nil
 
 }
 
-func GetAsset(md5 string) (*bytes.Buffer, swift.Headers, error) {
-	conf, err := config.GetConfig()
-	if err != nil {
-		return nil, nil, err
-	}
+func (s *SwiftFS) GetAsset(md5 string) (*bytes.Buffer, map[string]string, error) {
+	sc := s.Connection
 	buf := new(bytes.Buffer)
-	sc := conf.SwiftConnection
 	headers, err := sc.ObjectGet(AssetContainerName, md5, buf, false, nil)
 	if err != nil {
 		return nil, nil, err
@@ -83,46 +40,15 @@ func GetAsset(md5 string) (*bytes.Buffer, swift.Headers, error) {
 }
 
 // Remove asset cleans a UsedByEntry and deletes the asset is there are no more app using the asset
-func RemoveAsset(md5, versionFilepath string) error {
-	row := globalAssetStoreDB.Get(ctx, md5)
+func (s *SwiftFS) RemoveAsset(md5 string) error {
+	// No more app is using the asset, we are going to clean it from couch
+	// and swift
+	sc := s.Connection
 
-	var assetDoc *GlobalAsset
-	err := row.ScanDoc(&assetDoc)
-	if err != nil && kivik.StatusCode(err) != kivik.StatusNotFound {
-		return err
-	}
-
-	var updatedVersions []string
-	for _, versionfp := range assetDoc.UsedBy {
-		if versionfp == versionFilepath {
-			continue
-		}
-		updatedVersions = append(updatedVersions, versionfp)
-	}
-
-	if len(updatedVersions) > 0 {
-		assetDoc.UsedBy = updatedVersions
-		_, err := globalAssetStoreDB.Put(ctx, md5, assetDoc)
-		if err != nil {
-			return err
-		}
-	} else {
-		// No more app is using the asset, we are going to clean it from couch
-		// and swift
-		conf, err := config.GetConfig()
-		if err != nil {
-			return err
-		}
-		sc := conf.SwiftConnection
-
-		// Deleting the object from swift. If the object is not found, we should
-		// not crash
-		err = sc.ObjectDelete(AssetContainerName, md5)
-		if err != nil && err != swift.ObjectNotFound {
-			return err
-		}
-
-		_, err = globalAssetStoreDB.Delete(ctx, md5, assetDoc.Rev)
+	// Deleting the object from swift. If the object is not found, we should
+	// not crash
+	err := sc.ObjectDelete(AssetContainerName, md5)
+	if err != nil && err != swift.ObjectNotFound {
 		return err
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,15 +35,17 @@ func New() (*Config, error) {
 	}, nil
 }
 
-func GetConfig() (*Config, error) {
+func GetConfig() *Config {
+	return config
+}
+
+func Init() error {
 	var err error
-	if config == nil {
-		config, err = New()
-		if err != nil {
-			return nil, err
-		}
+	config, err = New()
+	if err != nil {
+		return err
 	}
-	return config, nil
+	return nil
 }
 
 func initSwiftConnection() (*swift.Connection, error) {

--- a/main.go
+++ b/main.go
@@ -1142,6 +1142,15 @@ func prepareRegistry(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Could not reach CouchDB: %s", err)
 	}
 
+	_, err = registry.InitGlobalAssetStore(
+		viper.GetString("couchdb.url"),
+		viper.GetString("couchdb.user"),
+		viper.GetString("couchdb.password"),
+		viper.GetString("couchdb.prefix"))
+	if err != nil {
+		return fmt.Errorf("Could not reach CouchDB: %s", err)
+	}
+
 	vault := auth.NewCouchDBVault(editorsDB)
 	editorRegistry, err = auth.NewEditorRegistry(vault)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -212,6 +212,11 @@ func useConfig(cmd *cobra.Command) (err error) {
 			cfgFile, err)
 	}
 
+	err = config.Init()
+	if err != nil {
+		return err
+	}
+
 	// Create cache
 	if redisURL := viper.GetString("redis.addrs"); redisURL != "" {
 		optsLatest := &redis.UniversalOptions{
@@ -356,10 +361,7 @@ var assetsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		var spacePrefix string
 
-		conf, err := config.GetConfig()
-		if err != nil {
-			return err
-		}
+		conf := config.GetConfig()
 		sc := conf.SwiftConnection
 
 		var spaces []string

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cozy/cozy-apps-registry/asset"
 	"github.com/cozy/cozy-apps-registry/auth"
 	"github.com/cozy/cozy-apps-registry/cache"
 	"github.com/cozy/cozy-apps-registry/config"
@@ -1142,7 +1143,7 @@ func prepareRegistry(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Could not reach CouchDB: %s", err)
 	}
 
-	_, err = registry.InitGlobalAssetStore(
+	_, err = asset.InitGlobalAssetStore(
 		viper.GetString("couchdb.url"),
 		viper.GetString("couchdb.user"),
 		viper.GetString("couchdb.password"),

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func init() {
 	rootCmd.AddCommand(addAppCmd)
 	rootCmd.AddCommand(modifyAppCmd)
 	rootCmd.AddCommand(maintenanceCmd)
+	rootCmd.AddCommand(rmAppVersionCmd)
 	maintenanceCmd.AddCommand(maintenanceActivateAppCmd)
 	maintenanceCmd.AddCommand(maintenanceDeactivateAppCmd)
 	rootCmd.AddCommand(exportCmd)
@@ -144,6 +145,7 @@ func init() {
 		fmt.Printf("Error on marking type flag as required: %s", err)
 	}
 	lsAppsCmd.Flags().StringVar(&appSpaceFlag, "space", "", "specify the application space")
+	rmAppVersionCmd.Flags().StringVar(&appSpaceFlag, "space", "", "specify the application space")
 
 	fixerCmd.Flags().StringSliceVar(&fixerSpacesFlag, "spaces", nil, "Specify spaces")
 	oldVersionsCmd.Flags().StringVar(&appSpaceFlag, "space", "", "specify the application space")
@@ -972,6 +974,30 @@ var addAppCmd = &cobra.Command{
 		}
 		fmt.Println(string(b))
 		return nil
+	},
+}
+
+var rmAppVersionCmd = &cobra.Command{
+	Use:     "rm-app-version <slug> <version>",
+	Short:   `Deletes an app version`,
+	PreRunE: compose(prepareRegistry, prepareSpaces),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		if len(args) != 2 {
+			return cmd.Help()
+		}
+		space, ok := registry.GetSpace(appSpaceFlag)
+		if !ok {
+			return fmt.Errorf("Space %q does not exist", appSpaceFlag)
+		}
+
+		slug := args[0]
+		version := args[1]
+
+		ver, err := registry.FindVersion(space, slug, version)
+		if err != nil {
+			return err
+		}
+		return ver.Delete(space)
 	},
 }
 

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -16,16 +16,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/Masterminds/semver"
 	"github.com/cozy/cozy-apps-registry/asset"
 	"github.com/cozy/cozy-apps-registry/cache"
 	"github.com/cozy/cozy-apps-registry/config"
+	"github.com/cozy/echo"
 	"github.com/cozy/swift"
 
-	"github.com/cozy/echo"
+	"github.com/Masterminds/semver"
 	"github.com/go-kivik/kivik"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -187,7 +187,7 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 	return att, nil
 }
 
-// MoveToGlobalAssetDatabase moves an asset located in the "local" container in
+// MoveAssetToGlobalDatabase moves an asset located in the "local" container in
 // the global database. This function is not intended to stay forever and will
 // be removed when no more assets will be remaining in the app containers.
 // It does the following steps:

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -186,15 +186,14 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 	return att, nil
 }
 
-// MoveToGlobalAssetDatabase moves the previous located asset in the global
-// database This function is not intended to stay forever and will be removed
-// when no more assets will be remaining in the app containers.
-// It does the
-// following steps:
+// MoveToGlobalAssetDatabase moves an asset located in the "local" container in
+// the global database. This function is not intended to stay forever and will
+// be removed when no more assets will be remaining in the app containers.
+// It does the following steps:
 // 1. Creating the new asset object in the global database
 // 2. Adds a reference to the asset in the couch version document
 // 3. Removes the old asset location
-func MoveAssetToGlobalDatabase(c *Space, ver *Version, buf *bytes.Reader, filename, contentType string) error {
+func MoveAssetToGlobalDatabase(c *Space, ver *Version, buf io.Reader, filename, contentType string) error {
 	globalFilepath := filepath.Join(c.Prefix, ver.Slug, ver.Version)
 
 	content, err := ioutil.ReadAll(buf)
@@ -203,7 +202,10 @@ func MoveAssetToGlobalDatabase(c *Space, ver *Version, buf *bytes.Reader, filena
 	}
 
 	h := md5.New()
-	h.Write(content)
+	_, err = h.Write(content)
+	if err != nil {
+		return err
+	}
 	md5Sum := h.Sum(nil)
 
 	a := &asset.GlobalAsset{

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -137,7 +137,9 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 
 	// First, we try to get the attachment from the global asset database.
 	ver, err := FindVersion(c, appSlug, version)
-
+	if err != nil {
+		return nil, err
+	}
 	md5Sum, ok := ver.AttachmentReferences[filename]
 	if ok {
 		contentBuffer, headers, err = asset.AssetStore.FS.GetAsset(md5Sum)

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -126,10 +126,7 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 	var fileContent []byte
 
 	// Return from swift
-	conf, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
+	conf := config.GetConfig()
 	sc := conf.SwiftConnection
 
 	var contentBuffer = new(bytes.Buffer)
@@ -230,10 +227,7 @@ func MoveAssetToGlobalDatabase(c *Space, ver *Version, content []byte, filename,
 		return err
 	}
 	// Remove the old object
-	conf, err := config.GetConfig()
-	if err != nil {
-		return err
-	}
+	conf := config.GetConfig()
 	sc := conf.SwiftConnection
 	fp := filepath.Join(GetPrefixOrDefault(c), ver.Slug, ver.Version)
 	return sc.ObjectDelete(fp, filename)

--- a/registry/finders.go
+++ b/registry/finders.go
@@ -141,7 +141,7 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 
 	md5Sum, ok := ver.AttachmentReferences[filename]
 	if ok {
-		contentBuffer, headers, err = asset.GetAsset(md5Sum)
+		contentBuffer, headers, err = asset.AssetStore.FS.GetAsset(md5Sum)
 		fileContent, err = ioutil.ReadAll(contentBuffer)
 		if err != nil {
 			return nil, err
@@ -155,7 +155,6 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 		}
 
 		fileContent = contentBuffer.Bytes()
-		contentType = headers["Content-Type"]
 
 		// We are going to move the asset to the global database and remove it
 		// from the local database for the next time
@@ -176,6 +175,7 @@ func FindVersionAttachment(c *Space, appSlug, version, filename string) (*Attach
 	}
 
 	content := bytes.NewReader(fileContent)
+	contentType = headers["Content-Type"]
 
 	att := &Attachment{
 		ContentType:   contentType,
@@ -213,7 +213,7 @@ func MoveAssetToGlobalDatabase(c *Space, ver *Version, buf *bytes.Reader, filena
 		ContentType: contentType,
 	}
 
-	err = asset.AddAsset(a, bytes.NewReader(content), globalFilepath)
+	err = asset.AssetStore.AddAsset(a, bytes.NewReader(content), globalFilepath)
 	if err != nil {
 		return err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -26,16 +26,16 @@ import (
 	"github.com/cozy/cozy-apps-registry/consts"
 	"github.com/cozy/cozy-apps-registry/errshttp"
 	"github.com/cozy/cozy-apps-registry/magic"
-	"github.com/cozy/swift"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-
-	multierror "github.com/hashicorp/go-multierror"
-
 	"github.com/cozy/echo"
+	"github.com/cozy/swift"
+
 	_ "github.com/go-kivik/couchdb" // for couchdb
 	"github.com/go-kivik/couchdb/chttp"
 	"github.com/go-kivik/kivik"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 const maxApplicationSize = 20 * 1024 * 1024 // 20 Mo
@@ -334,7 +334,6 @@ func InitGlobalClient(addr, user, pass, prefix string) (editorsDB *kivik.DB, err
 	}
 
 	editorsDB = globalEditorsDB
-
 	return
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -588,10 +588,6 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 	// Storing the attachments to swift (screenshots, icon, partnership_icon)
 	basePath := filepath.Join(c.Prefix, ver.Slug, ver.Version)
 
-	prefix := c.Prefix
-	if prefix == "" {
-		prefix = consts.DefaultSpacePrefix
-	}
 	var atts = map[string]string{}
 
 	for _, att := range attachments {
@@ -606,7 +602,7 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 		}
 		md5sum := h.Sum(nil)
 
-		// Adding asset to the global database
+		// Adding asset to the global asset store
 		a := &asset.GlobalAsset{
 			Name:        att.Filename,
 			MD5:         hex.EncodeToString(md5sum),
@@ -618,7 +614,7 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 			return err
 		}
 
-		// We are going to use the _attachment field to store a link to the
+		// We are going to use the attachment field to store a link to the
 		// global asset
 		atts[att.Filename] = hex.EncodeToString(md5sum)
 	}
@@ -1163,20 +1159,6 @@ func (v *Version) Delete(c *Space) error {
 	db := c.VersDB()
 	_, err = db.Delete(context.Background(), v.ID, v.Rev)
 	return err
-}
-
-// RemoveAttachment removes one attachment from a version
-func (v *Version) RemoveAttachment(c *Space, filename string) error {
-	prefix := GetPrefixOrDefault(c)
-
-	conf, err := config.GetConfig()
-	if err != nil {
-		return err
-	}
-	sc := conf.SwiftConnection
-	fp := filepath.Join(v.Slug, v.Version, filename)
-
-	return sc.ObjectDelete(prefix, fp)
 }
 
 // RemoveAllAttachments removes all the attachments of a version

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -586,7 +586,7 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 	}
 
 	// Storing the attachments to swift (screenshots, icon, partnership_icon)
-	basePath := filepath.Join(ver.Slug, ver.Version)
+	basePath := filepath.Join(c.Prefix, ver.Slug, ver.Version)
 
 	prefix := c.Prefix
 	if prefix == "" {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -613,7 +613,7 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 			AppSlug:     app.Slug,
 			ContentType: att.ContentType,
 		}
-		err = asset.AddAsset(a, buf, basePath)
+		err = asset.AssetStore.AddAsset(a, buf, basePath)
 		if err != nil {
 			return err
 		}
@@ -1193,7 +1193,7 @@ func (v *Version) RemoveAllAttachments(c *Space) error {
 	if v.AttachmentReferences != nil {
 		for _, md5 := range v.AttachmentReferences {
 			key := asset.MarshalAssetKey(prefix, v.Slug, v.Version)
-			err = asset.RemoveAsset(md5, key)
+			err = asset.AssetStore.RemoveAsset(md5, key)
 			if err != nil {
 				return err
 			}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -585,7 +585,7 @@ func createVersion(c *Space, db *kivik.DB, ver *Version, attachments []*kivik.At
 	}
 
 	// Storing the attachments to swift (screenshots, icon, partnership_icon)
-	basePath := filepath.Join(c.Prefix, ver.Slug, ver.Version)
+	basePath := asset.MarshalAssetKey(c.Prefix, ver.Slug, ver.Version)
 
 	var atts = map[string]string{}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -643,10 +643,7 @@ func (version *Version) Clone() *Version {
 }
 
 func ApprovePendingVersion(c *Space, pending *Version, app *App) (*Version, error) {
-	conf, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
+	conf := config.GetConfig()
 	db := c.PendingVersDB()
 
 	release := pending.Clone()
@@ -666,7 +663,7 @@ func ApprovePendingVersion(c *Space, pending *Version, app *App) (*Version, erro
 
 	// We need to skip version check, because we don't drop pending
 	// version until the end to avoid data loss in case of error
-	err = CreateReleaseVersion(c, release, attachments, app, false)
+	err := CreateReleaseVersion(c, release, attachments, app, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1162,12 +1159,10 @@ func (v *Version) Delete(c *Space) error {
 
 // RemoveAllAttachments removes all the attachments of a version
 func (v *Version) RemoveAllAttachments(c *Space) error {
+	var err error
 	prefix := GetPrefixOrDefault(c)
 
-	conf, err := config.GetConfig()
-	if err != nil {
-		return err
-	}
+	conf := config.GetConfig()
 	sc := conf.SwiftConnection
 
 	// Dereferences this version from global asset store

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -76,6 +76,7 @@ const (
 	versDBSuffix        = "versions"
 	pendingVersDBSuffix = "pending"
 	editorsDBSuffix     = "editors"
+	assetStoreDBSuffix  = "assets"
 )
 
 const (
@@ -100,8 +101,9 @@ var (
 	clientURL *url.URL
 	spaces    map[string]*Space
 
-	globalPrefix    string
-	globalEditorsDB *kivik.DB
+	globalPrefix       string
+	globalEditorsDB    *kivik.DB
+	globalAssetStoreDB *kivik.DB
 
 	ctx = context.Background()
 
@@ -329,7 +331,31 @@ func InitGlobalClient(addr, user, pass, prefix string) (editorsDB *kivik.DB, err
 	}
 
 	editorsDB = globalEditorsDB
+
 	return
+}
+
+// InitGlobalAssetStore initializes the global asset store database
+func InitGlobalAssetStore(addr, user, pass, prefix string) (*kivik.DB, error) {
+	assetsStoreDBName := dbName(assetStoreDBSuffix)
+	exists, err := client.DBExists(ctx, assetsStoreDBName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		fmt.Printf("Creating database %q...", assetsStoreDBName)
+		if _, err = client.CreateDB(ctx, assetsStoreDBName); err != nil {
+			return nil, err
+		}
+		fmt.Println("ok.")
+	}
+
+	globalAssetStoreDB, err = client.DB(ctx, assetsStoreDBName)
+	if err != nil {
+		return nil, err
+	}
+
+	return globalAssetStoreDB, nil
 }
 
 func RegisterSpace(name string) error {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1189,6 +1189,17 @@ func (v *Version) RemoveAllAttachments(c *Space) error {
 	}
 	sc := conf.SwiftConnection
 
+	// Dereferences this version from global asset store
+	if v.AttachmentReferences != nil {
+		for _, md5 := range v.AttachmentReferences {
+			key := asset.MarshalAssetKey(prefix, v.Slug, v.Version)
+			err = asset.RemoveAsset(md5, key)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	fp := filepath.Join(v.Slug, v.Version)
 	opts := &swift.ObjectsOpts{Prefix: fp + "/"}
 	objs, err := sc.ObjectsAll(prefix, opts)

--- a/router.go
+++ b/router.go
@@ -487,7 +487,7 @@ func getAppPartnershipIcon(c echo.Context) error {
 }
 
 func getAppScreenshot(c echo.Context) error {
-	filename := path.Join("/", "screenshots", c.Param("*"))
+	filename := path.Join("screenshots", c.Param("*"))
 	err := getAppAttachment(c, filename)
 	if err != nil {
 		if errh, ok := err.(*echo.HTTPError); ok && errh.Code == http.StatusNotFound {
@@ -555,7 +555,7 @@ func getVersionPartnershipIcon(c echo.Context) error {
 }
 
 func getVersionScreenshot(c echo.Context) error {
-	filename := path.Join("/", "screenshots", c.Param("*"))
+	filename := path.Join("screenshots", c.Param("*"))
 	err := getVersionAttachment(c, filename)
 	if err != nil {
 		if errh, ok := err.(*echo.HTTPError); ok && errh.Code == http.StatusNotFound {

--- a/router.go
+++ b/router.go
@@ -125,10 +125,7 @@ func checkAuthorized(c echo.Context) error {
 }
 
 func createVersion(c echo.Context) (err error) {
-	conf, err := config.GetConfig()
-	if err != nil {
-		return err
-	}
+	conf := config.GetConfig()
 	if err = checkAuthorized(c); err != nil {
 		return err
 	}

--- a/router.go
+++ b/router.go
@@ -490,7 +490,7 @@ func getAppPartnershipIcon(c echo.Context) error {
 }
 
 func getAppScreenshot(c echo.Context) error {
-	filename := path.Join("screenshots", c.Param("*"))
+	filename := path.Join("/", "screenshots", c.Param("*"))
 	err := getAppAttachment(c, filename)
 	if err != nil {
 		if errh, ok := err.(*echo.HTTPError); ok && errh.Code == http.StatusNotFound {
@@ -558,7 +558,7 @@ func getVersionPartnershipIcon(c echo.Context) error {
 }
 
 func getVersionScreenshot(c echo.Context) error {
-	filename := path.Join("screenshots", c.Param("*"))
+	filename := path.Join("/", "screenshots", c.Param("*"))
 	err := getVersionAttachment(c, filename)
 	if err != nil {
 		if errh, ok := err.(*echo.HTTPError); ok && errh.Code == http.StatusNotFound {


### PR DESCRIPTION
This PR adds a global asset store in order to avoid asset duplication for different app versions. Each asset of an app will now be stored in the global store instead of local FS container.

New published applications will check along its MD5 sum if the asset exists in the global store. If not, the asset will be created. The CouchDB app version document will then update to link each asset filename with an object of the asset store.

Current applications will progressively update themselves. Each time an icon, screenshot or partnership_icon is requested and still located in the local store, it will me moved in the global one.  