### PR TITLE
Use opts.Version instead of manifest.Version for tarball path

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1023,7 +1023,7 @@ func downloadVersion(opts *VersionOptions) (*Version, []*kivik.Attachment, error
 	parsedManifest := tarball.Manifest
 
 	filename := filepath.Base(url)
-	filepath := filepath.Join(parsedManifest.Slug, parsedManifest.Version, filename)
+	filepath := filepath.Join(parsedManifest.Slug, opts.Version, filename)
 
 	// Saving app tarball
 	errt := SaveTarball(opts.Space, filepath, tarball)


### PR DESCRIPTION
For dev and beta application versions, some webapps/konnectors use the
next version number as the "official" version number in the manifest (ie: 1.0.0
instead of 1.0.0-dev.abcdef). This was leading to a false generated
download URL as the registry was relying on this manifest version. It
should be fixed with this patch.