### PR TITLE
Add safeguards for virtual spaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -473,6 +473,14 @@ var rmSpaceCmd = &cobra.Command{
 			return cmd.Usage()
 		}
 		space := args[0]
+
+		// Check the space is not a virtual one
+		for _, vkey := range getVspaceKeys(viper.GetStringMap("virtual_spaces")) {
+			if space == vkey {
+				return fmt.Errorf("Warning: \"%s\" is a virtual space, just remove the entry from your config file.", space)
+			}
+		}
+
 		s, ok := registry.GetSpace(space)
 		if !ok {
 			return fmt.Errorf("Cannot find space %s", space)
@@ -1214,13 +1222,18 @@ func prepareRegistry(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// checkSpaceVspaceOverlap checks if a space and a vspace holds the same name
-func checkSpaceVspaceOverlap(spaces []string, vspaces map[string]interface{}) (bool, string) {
-	// Retreiving vspaces keys
+func getVspaceKeys(vspaces map[string]interface{}) []string {
 	vspaceKeys := make([]string, 0, len(vspaces))
 	for k := range vspaces {
 		vspaceKeys = append(vspaceKeys, k)
 	}
+	return vspaceKeys
+}
+
+// checkSpaceVspaceOverlap checks if a space and a vspace holds the same name
+func checkSpaceVspaceOverlap(spaces []string, vspaces map[string]interface{}) (bool, string) {
+	// Retreiving vspaces keys
+	vspaceKeys := getVspaceKeys(vspaces)
 	for _, vspace := range vspaceKeys {
 		for _, space := range spaces {
 			if vspace == space {


### PR DESCRIPTION
This PR adds small QoL improvements for virtual spaces:

- Checks if a space and a virtual space have the same name at startup
- Tells the user if the space is virtual during rm-space   