### PR TITLE
Handle universal link urls with subpaths

### DIFF
--- a/router.go
+++ b/router.go
@@ -1139,6 +1139,7 @@ func Router(addr string) *echo.Echo {
 
 	e.GET("/.well-known/:filename", universalLink, middleware.Gzip())
 	e.GET("/:slug", universalLinkRedirect)
+	e.GET("/:slug/*", universalLinkRedirect)
 
 	e.GET("/favicon.ico", func(c echo.Context) error {
 		return c.Blob(http.StatusOK, "image/png", faviconBytes)


### PR DESCRIPTION
This PR allows subpaths to be matched for universal links, like `http://foobar.com/drive/foo/bar?fallback=http://myinstance.mycozy.cloud`