### PR TITLE
Allow env variables to override nested conf params

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func init() {
 
 func useConfig(cmd *cobra.Command) (err error) {
 	viper.SetEnvPrefix("cozy_registry")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 	viper.SetDefault("port", 8080)
 	viper.SetDefault("host", "localhost")


### PR DESCRIPTION
This PR allows the infra team to override nested conf params by env variables