### PR TITLE
chore: Add config files for universal links

### DIFF
--- a/config/universallinks/apple-app-site-association
+++ b/config/universallinks/apple-app-site-association
@@ -1,0 +1,16 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "3AKXFMV43J.io.cozy.drive.mobile",
+        "paths": ["/drive" , "/drive/*"]
+      },
+{
+	"appID": "3AKXFMV43J.io.cozy.banks",
+	"paths": ["/banks" , "/banks/*"]
+}
+    ]
+  }
+}
+

--- a/config/universallinks/assetlinks.json
+++ b/config/universallinks/assetlinks.json
@@ -1,0 +1,9 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "io.cozy.banks.mobile",
+    "sha256_cert_fingerprints":
+    ["B6:F8:37:B7:D5:BC:6E:C9:17:7E:89:17:B6:06:C9:1B:E2:D0:05:3C:D6:53:2B:8D:8E:37:B2:87:24:27:91:89"]
+  }
+}]


### PR DESCRIPTION
Those files are served by the app registry. They are used for universal link on Android and iOS 