### PR TITLE
Minimize latency for GetAppsList

### DIFF
--- a/cache/lru.go
+++ b/cache/lru.go
@@ -23,6 +23,7 @@ import (
 type Cache interface {
 	Add(Key, Value)
 	Get(Key) (Value, bool)
+	MGet([]Key) []interface{}
 	Remove(Key)
 }
 
@@ -96,6 +97,17 @@ func (c *LRUCache) Get(key Key) (value Value, ok bool) {
 		c.removeElement(ele)
 	}
 	return
+}
+
+// MGet looks up several keys at once from the cache.
+func (c *LRUCache) MGet(keys []Key) []interface{} {
+	values := make([]interface{}, len(keys))
+	for i, key := range keys {
+		if val, ok := c.Get(key); ok {
+			values[i] = []byte(val)
+		}
+	}
+	return values
 }
 
 // Remove removes the provided key from the cache.

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -42,6 +42,15 @@ func (c *RedisCache) MGet(keys []Key) []interface{} {
 		strs[i] = k.String()
 	}
 	if values, err := c.cache.MGet(strs...).Result(); err == nil {
+		for i, v := range values {
+			if s, ok := v.(string); ok {
+				if s == "" {
+					values[i] = nil
+				} else {
+					values[i] = []byte(s)
+				}
+			}
+		}
 		return values
 	}
 	return make([]interface{}, len(keys))

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"time"
 
+	"github.com/cozy/cozy-apps-registry/utils"
 	"github.com/go-redis/redis"
 )
 
@@ -22,7 +23,8 @@ func NewRedisCache(ttl time.Duration, client redis.UniversalClient) *RedisCache 
 
 // Add adds a value to the cache.
 func (c *RedisCache) Add(key Key, value Value) {
-	c.cache.Set(key.String(), []byte(value), c.TTL)
+	ttl := utils.DurationFuzzing(c.TTL, 0.2)
+	c.cache.Set(key.String(), []byte(value), ttl)
 }
 
 // Get looks up a key's value from the cache.
@@ -31,6 +33,18 @@ func (c *RedisCache) Get(key Key) (value Value, ok bool) {
 		return []byte(val), true
 	}
 	return nil, false
+}
+
+// MGet looks up several keys at once from the cache.
+func (c *RedisCache) MGet(keys []Key) []interface{} {
+	strs := make([]string, len(keys))
+	for i, k := range keys {
+		strs[i] = k.String()
+	}
+	if values, err := c.cache.MGet(strs...).Result(); err == nil {
+		return values
+	}
+	return make([]interface{}, len(keys))
 }
 
 // Remove removes the provided key from the cache.

--- a/cache/redis_test.go
+++ b/cache/redis_test.go
@@ -23,7 +23,7 @@ func TestRedis(t *testing.T) {
 		t.Fatal("should have key", key)
 	}
 
-	time.Sleep(101 * time.Millisecond)
+	time.Sleep(121 * time.Millisecond)
 
 	if _, ok := redisCache.Get(key); ok {
 		t.Fatal("should not have key", key)

--- a/utils/duration_fuzzing.go
+++ b/utils/duration_fuzzing.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"math/rand"
+	"time"
+)
+
+// DurationFuzzing returns a duration that is near the given duration, but
+// randomized to avoid patterns like several cache entries that expires at the
+// same time.
+func DurationFuzzing(d time.Duration, variation float64) time.Duration {
+	if variation > 1.0 || variation < 0.0 {
+		panic("DurationRandomized: variation should be between 0.0 and 1.0")
+	}
+	return time.Duration(float64(d) * (1.0 + variation*(2.0*rand.Float64()-1.0)))
+}


### PR DESCRIPTION
This PR prevents multiple-network requests on cache (if redis is configured as the backend cache) by storing all the app versions and latest app version as a single json (one for version, one for latest)