### PR TITLE
Add universal link special case for iOS

### DIFF
--- a/registry/finders.go
+++ b/registry/finders.go
@@ -340,13 +340,8 @@ func FindLastsVersionsSince(c *Space, appSlug, channel string, date time.Time) (
 	db := c.VersDB()
 	versions := []*Version{}
 
-	marshaled, err := json.Marshal(date.Format(time.RFC3339Nano))
-	if err != nil {
-		return nil, err
-	}
-
 	options := map[string]interface{}{
-		"startkey":     string(marshaled),
+		"startkey":     date.Format(time.RFC3339Nano),
 		"include_docs": true,
 	}
 


### PR DESCRIPTION
Some iOS devices (1-2%) are affected by a bug during apple-app-site json
file retrieving. This commit adds a workaround for these users by
forcing a custom schema if the app is installed