### PR TITLE
Fix mime-type of SVG image

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -12,7 +12,9 @@ import (
 // a good result, we fallback on guessing from the filename extension.
 func getMIMEType(name string, data []byte) string {
 	sniffed := http.DetectContentType(data)
-	if sniffed != "application/octet-stream" && sniffed != "text/plain" {
+	// application/octet-stream is the default, when not detected
+	// SVG image are often detected as text/xml or text/plain with a charset
+	if sniffed != "application/octet-stream" && !strings.HasPrefix(sniffed, "text/") {
 		return sniffed
 	}
 

--- a/registry/utils_test.go
+++ b/registry/utils_test.go
@@ -1,0 +1,12 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMIMEType(t *testing.T) {
+	mime := getMIMEType("icon.svg", []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"></svg>`))
+	assert.Equal(t, "image/svg+xml", mime)
+}


### PR DESCRIPTION
With new versions of Go, the detected mime-type for SVG images has
changed from text/plain to text/plain; charset=utf-8. And we had a
strict comparison to text/plain to force a fallback.