### PR TITLE
Avoid errors on move_asset when the ID is missing

### DIFF
--- a/registry/finders.go
+++ b/registry/finders.go
@@ -144,8 +144,9 @@ func FindVersionAttachment(c *space.Space, version *Version, filename string) (*
 	contentType = headers["Content-Type"]
 
 	// If the asset was not found in the global database, move it for the next
-	// time.
-	if !ok {
+	// time (except when the ID is missing on the version, which is the case
+	// when the version was loaded via FindLatestVersion).
+	if !ok && version.ID != "" {
 		go func() {
 			err := MoveAssetToGlobalDatabase(c, version, fileContent, filename, contentType)
 			if err != nil {
@@ -153,7 +154,7 @@ func FindVersionAttachment(c *space.Space, version *Version, filename string) (*
 					"nspace":    "move_asset",
 					"space":     c.Name,
 					"slug":      slug,
-					"version":   version,
+					"version":   version.Version,
 					"filename":  filename,
 					"error_msg": err,
 				})


### PR DESCRIPTION
The issue comes from this path in the code:

- it starts with
  https://github.com/nono/cozy-apps-registry/blob/233b91606cb6e652ca1fd6d282a6c29d723e7797/registry/virtual.go#L287-L298
- which loads the last version of the app, but without its ID
  https://github.com/nono/cozy-apps-registry/blob/233b91606cb6e652ca1fd6d282a6c29d723e7797/registry/finders.go#L502
- then calls getOriginalTarball, which calls FindVersionAttachment
- and it ends on the problematic call to move_asset
  https://github.com/nono/cozy-apps-registry/blob/233b91606cb6e652ca1fd6d282a6c29d723e7797/registry/finders.go#L150-L161