### PR TITLE
doc: add mobile attribute in manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Field              | Description
 `locales`          | an object with language slug as property, each name property is an object of localized informations (see the second part below)
 `manifest_version` | The current manifest version used. This is a versioning for the manifest and allow better retrocompatiblity when processing app manifest
 `messages`         | _(konnector specific)_ Array of message identifiers, which can be used by application to display information at known areas. See [example below](#konnectors-message-property).
+`mobile`           | _(application specific)_ JSON object containing information about app's mobile version (see [cozy-stack routes doc](https://docs.cozy.io/en/cozy-stack/apps/#mobile) for more details)
 `name`             | the name to display on the home (__REQUIRED__)
 `name_prefix`      | the prefix to display with the name
 `oauth`            | _(konnector specific)_ JSON object containing oAuth information, like `scope`. If a manifest provides an `oauth` property, it is considered as an OAuth konnector. Note: scope can be a string or an array. If it is an array, its values will be joined with a space. A `false` or `null` value in scope will remove any scope parameter in the request sent to the oauth provider.


### PR DESCRIPTION
This attribute allows to declare mobile information in apps manifests

---

⚠️ Link in the doc will not be valid until https://github.com/cozy/cozy-stack/pull/3263 is merged

---

See related PR:
- https://github.com/cozy/cozy-stack/pull/3263
- https://github.com/cozy/cozy-pass-web/pull/78
- https://github.com/cozy/cozy-react-native/pull/65
- https://github.com/cozy/cozy-home/pull/1680
- https://github.com/cozy/cozy-ui/pull/2015

