### PR TITLE
Fix client address in log when behind a proxy

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,9 @@ func Root() *cobra.Command {
 	flags.Int("port", 8080, "port to listen on")
 	checkNoErr(viper.BindPFlag("port", flags.Lookup("port")))
 
+	flags.String("access_topology", "direct", "access topology in front of application")
+	checkNoErr(viper.BindPFlag("access_topology", flags.Lookup("access_topology")))
+
 	flags.String("couchdb-url", "http://localhost:5984", "address of couchdb")
 	checkNoErr(viper.BindPFlag("couchdb.url", flags.Lookup("couchdb-url")))
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ func SetDefaults() {
 	viper.AutomaticEnv()
 	viper.SetDefault("port", 8080)
 	viper.SetDefault("host", "localhost")
+	viper.SetDefault("network_topology", "direct") // Direct connection from internet
 	viper.SetDefault("couchdb.url", "http://localhost:5984/")
 	viper.SetDefault("couchdb.prefix", "cozyregistry")
 	viper.SetDefault("conservation.enable_background_cleaning", false)

--- a/cozy-registry.example.yml
+++ b/cozy-registry.example.yml
@@ -3,6 +3,13 @@ host: "127.0.0.1"
 # server port (serve command) - flag --port
 port: 8081
 
+# Network topology in front of cozy apps registry
+# allowed values are:
+# - direct: (default) application is directly serving clients, with no reverse proxy. Client IP is available at network level
+# - xff: A reverse proxy is forwarding trafic to the application and save the client's real IP in the X-Forwarded-For HTTP header
+# - xrip: A reverse proxy is forwarding trafic to the application and save the client's real IP in the X-Real-IP HTTP header
+access_topology: "direct"
+
 couchdb:
   # CouchDB server url - flag --couchdb-url
   url: http://localhost:5984

--- a/web/router.go
+++ b/web/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 const authTokenScheme = "Token "
@@ -236,7 +237,7 @@ func httpErrorHandler(err error, c echo.Context) {
 		"is_json":     isJSON,
 		"method":      c.Request().Method,
 		"request_uri": c.Request().RequestURI,
-		"remote_ip":   c.Request().RemoteAddr,
+		"remote_ip":   c.RealIP(),
 		"status":      code,
 		"error_msg":   msg,
 	})
@@ -346,6 +347,14 @@ func Router() *echo.Echo {
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
+	switch viper.GetString("access_topology") {
+	case "direct":
+		e.IPExtractor = echo.ExtractIPDirect()
+	case "xff":
+		e.IPExtractor = echo.ExtractIPFromXFFHeader()
+	case "xrip":
+		e.IPExtractor = echo.ExtractIPFromRealIPHeader()
+	}
 	e.HTTPErrorHandler = httpErrorHandler
 
 	e.Pre(middleware.RemoveTrailingSlash())


### PR DESCRIPTION
When logging errors, cozy-apps-registry also log client_IP.

Unfortunately, it takes client IP at network level and that is not correct when using a reverse proxy or a load balancer acting as a reverse proxy.

This PR adds a new configuration item `access_topology` used to tell the application how it is accessed, either directly (so the client IP should be taken at network level like it is doing now), behind a reverse proxy setting client IP in a `X-Forwarded-For` HTTP header or behind a reverse proxy setting client_ip in a `X-Real-IP` HTTP Header.

It then log request errors with correct client IP.