### PR TITLE
Add config values validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -169,7 +169,11 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		config.SetDefaults()
-		return config.ReadFile(cfgFileFlag, "cozy-registry")
+		if err := config.ReadFile(cfgFileFlag, "cozy-registry"); err != nil {
+			return err
+		}
+		return config.Validate()
+
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,16 @@ func SetDefaults() {
 	viper.SetDefault("conservation.month", 2)
 }
 
+// Validate the config items loaded in viper requiring validation.
+func Validate() error {
+	topology := viper.GetString("access_topology")
+	if (topology != "direct") && (topology != "xff") && (topology != "xrip") {
+		return fmt.Errorf("Unknown access_topology value in configuration: %s", topology)
+	}
+
+	return nil
+}
+
 // ReadFile reads the config file, parses it, and loads the values in viper.
 func ReadFile(file, defaultFile string) error {
 	if file == "" {


### PR DESCRIPTION
This PR adds a config values validation. Currently only used to validate access_topology value.