### PR TITLE
Make oversized application bundle error explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,11 @@ __:warning: Here the `slug` is the unique ID of the application in the registry,
 
 ### 3) Add a new version of a registered application
 
+    > :warning: Please note that an application bundle cannot be larger than 20MB (hardcoded value).
+    This limitation has been implemented to encourage better web application development practices
+    because in general the larger the application bundle is, the worst the performance and
+    user experience will be.
+
 #### Via [`cozy-app-publish`][cozy-app-publish] (highly recommanded)
 
 __Here we will show the classical way to add a version using the manual mode of [`cozy-app-publish`][cozy-app-publish] as reference. But you may need to look at  the [Automation CI part](#automation-ci) of this documentation instead.__


### PR DESCRIPTION
When publishing a new version of a registered application with a bundle larger that the hardcoded `maxApplicationSize`, the registry were truncating the bundle and replying with an `Invalid Checksum` error.
This PR fixes that behaviour by returning an explicit error when submitting an oversized application bundle, including the limit value.

A warning has also been added to the documentation.