### PR TITLE
Fix a panic when reading a tarball

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -549,13 +549,13 @@ func tarReader(reader io.ReadSeeker, contentType string) (*tar.Reader, error) {
 		"application/x-gzip",
 		"application/x-tgz",
 		"application/tar+gzip":
-		r, err = gzip.NewReader(reader)
-		if err != nil {
+		if r, err = gzip.NewReader(reader); err != nil {
 			return nil, err
 		}
 	case "application/octet-stream":
 		if r, err = gzip.NewReader(reader); err != nil {
 			_, _ = reader.Seek(0, io.SeekStart)
+			r = reader
 		}
 	}
 	return tar.NewReader(r), nil


### PR DESCRIPTION
When a tarball not gzipped is uploaded with the content-type application/octet-stream, there was a panic. It was caused by code trying to detect if the tarball is gzipped or not, and if not gzipped, we were trying to read from the nil gzip reader.