### PR TITLE
Add flag to show space type in ls-spaces

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ var majorFlag int
 var durationFlag int
 var physicalFlag bool
 var virtualFlag bool
+var withSpaceTypeFlag bool
 var forceFlag bool
 var noDryRunFlag bool
 var editorAutoPublicationFlag bool
@@ -150,8 +151,9 @@ func Root() *cobra.Command {
 	modifyAppCmd.Flags().StringVar(&appDUCFlag, "data-usage-commitment", "", "Specify the data usage commitment: user_ciphered, user_reserved or none")
 	modifyAppCmd.Flags().StringVar(&appDUCByFlag, "data-usage-commitment-by", "", "Specify the usage commitment author: cozy, editor or none")
 
-	lsSpaceCmd.Flags().BoolVar(&physicalFlag, "physical", false, "show physical spaces")
-	lsSpaceCmd.Flags().BoolVar(&virtualFlag, "virtual", false, "show virtual spaces")
+	lsSpaceCmd.Flags().BoolVar(&physicalFlag, "physical", false, "Show physical spaces")
+	lsSpaceCmd.Flags().BoolVar(&virtualFlag, "virtual", false, "Show virtual spaces")
+	lsSpaceCmd.Flags().BoolVar(&withSpaceTypeFlag, "with-space-type", false, "Display space type alongside space name")
 	rmSpaceCmd.Flags().BoolVar(&forceFlag, "force", false, "skip confirmation prompt")
 	maintenanceActivateAppCmd.Flags().BoolVar(&infraMaintenanceFlag, "infra", false, "specify a maintenance specific to our infra")
 	maintenanceActivateAppCmd.Flags().BoolVar(&shortMaintenanceFlag, "short", false, "specify a short maintenance")

--- a/cmd/space.go
+++ b/cmd/space.go
@@ -55,17 +55,27 @@ var lsSpaceCmd = &cobra.Command{
 	Long:    `List all configured spaces`,
 	PreRunE: compose(prepareRegistry, prepareSpaces),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var spaceList []string
+		var physicalSpaceList []string
+		var virtualSpaceList []string
 
 		if physicalFlag || !virtualFlag {
-			spaceList = config.GetSpaces()
+			physicalSpaceList = config.GetSpaces()
 		}
-
 		if virtualFlag || !physicalFlag {
-			spaceList = append(spaceList, config.GetVirtualSpaces()...)
+			virtualSpaceList = config.GetVirtualSpaces()
 		}
 
-		fmt.Println(strings.Join(spaceList, "\n"))
+		if !withSpaceTypeFlag {
+			fmt.Println(strings.Join(append(physicalSpaceList, virtualSpaceList...), "\n"))
+		} else {
+			for _, sp := range physicalSpaceList {
+				fmt.Println("physical", sp)
+			}
+			for _, sp := range virtualSpaceList {
+				fmt.Println("virtual", sp)
+			}
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
Add a `--with-space-type` flag to show space type (physical/virtual) in ls-spaces command