### PR TITLE
Add redis logger

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,16 +100,17 @@ func Root() *cobra.Command {
 	rootCmd.AddCommand(rmAppCmd)
 	rootCmd.AddCommand(overwriteAppNameCmd)
 	rootCmd.AddCommand(overwriteAppIconCmd)
-	rootCmd.AddCommand(maintenanceCmd)
 	rootCmd.AddCommand(rmAppVersionCmd)
 	rootCmd.AddCommand(lsSpaceCmd)
 	rootCmd.AddCommand(rmSpaceCmd)
-	maintenanceCmd.AddCommand(maintenanceActivateAppCmd)
-	maintenanceCmd.AddCommand(maintenanceDeactivateAppCmd)
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(oldVersionsCmd)
 	rootCmd.AddCommand(completionCmd)
+
+	rootCmd.AddCommand(maintenanceCmd)
+	maintenanceCmd.AddCommand(maintenanceActivateAppCmd)
+	maintenanceCmd.AddCommand(maintenanceDeactivateAppCmd)
 
 	passphraseFlag = genSessionSecret.Flags().Bool("passphrase", false, "enforce or dismiss the session secret encryption")
 
@@ -177,7 +178,12 @@ var rootCmd = &cobra.Command{
 		if err := config.ReadFile(cfgFileFlag, "cozy-registry"); err != nil {
 			return err
 		}
-		return config.Validate()
+		if err := config.Validate(); err != nil {
+			return err
+		}
+
+		config.SetupLogger(config.LoggerOptions{Syslog: viper.GetBool("syslog")})
+		return nil
 
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -190,7 +196,6 @@ var serveCmd = &cobra.Command{
 	Short:   `Start the registry HTTP server`,
 	PreRunE: compose(loadSessionSecret, prepareRegistry, prepareSpaces),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		config.SetupLogger(config.LoggerOptions{Syslog: viper.GetBool("syslog")})
 		address := fmt.Sprintf("%s:%d", viper.GetString("host"), viper.GetInt("port"))
 		fmt.Printf("Listening on %s...\n", address)
 		errc := make(chan error)

--- a/config/logger.go
+++ b/config/logger.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"io"
 	"io/ioutil"
+	stdlog "log"
 	"log/syslog"
 
+	"github.com/go-redis/redis/v7"
 	"github.com/sirupsen/logrus"
 	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
@@ -15,11 +18,19 @@ type LoggerOptions struct {
 
 // SetupLogger configures the logger.
 func SetupLogger(opts LoggerOptions) {
+	var w io.Writer
+	// Not closing w as it should be kept open until process dies
+
 	if opts.Syslog {
 		hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "cozy-apps-registry")
 		if err == nil {
 			logrus.AddHook(hook)
 			logrus.SetOutput(ioutil.Discard)
 		}
+		w = logrus.WithField("nspace", "go-redis").Writer()
+	} else {
+		w = io.Discard
 	}
+
+	redis.SetLogger(stdlog.New(w, "", 0))
 }


### PR DESCRIPTION
This PR:

- Move logger initialization earlier at process start, before `loadSessionSecret`, `prepareRegistry` and `prepareSpaces`
- Add a logger to go-redis
  - use syslog logger if started with syslog flag
  - discard redis logs otherwise to avoid outputing syslog info/debug messages to stderr when using cli

Big thanks to @taratatach for his help on this one