### PR TITLE
Speedup ls-apps cmd

### DIFF
--- a/asset/store_test.go
+++ b/asset/store_test.go
@@ -136,7 +136,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := config.PrepareSpaces(); err != nil {
+	if err := config.PrepareSpaces(true); err != nil {
 		fmt.Println("Cannot prepare the spaces:", err)
 		os.Exit(1)
 	}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -16,7 +16,7 @@ import (
 var lsAppsCmd = &cobra.Command{
 	Use:     "ls-apps [editor]",
 	Short:   `List all apps from an editor`,
-	PreRunE: compose(prepareRegistry, prepareSpaces),
+	PreRunE: compose(prepareRegistry, prepareSpacesWithoutStorage),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c, ok := space.GetSpace(appSpaceFlag)
 		if !ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,7 +223,11 @@ func prepareRegistry(cmd *cobra.Command, args []string) error {
 }
 
 func prepareSpaces(cmd *cobra.Command, args []string) error {
-	return config.PrepareSpaces()
+	return config.PrepareSpaces(true)
+}
+
+func prepareSpacesWithoutStorage(cmd *cobra.Command, args []string) error {
+	return config.PrepareSpaces(false)
 }
 
 func loadSessionSecret(cmd *cobra.Command, args []string) error {

--- a/config/services.go
+++ b/config/services.go
@@ -325,7 +325,7 @@ func GetVirtualSpaces() []string {
 
 // PrepareSpaces makes sure that the CouchDB databases and Swift containers for
 // the spaces exist and have their index/views.
-func PrepareSpaces() error {
+func PrepareSpaces(initStorage bool) error {
 	spaceNames := GetSpaces()
 	space.Spaces = make(map[string]*space.Space)
 
@@ -345,9 +345,11 @@ func PrepareSpaces() error {
 			return fmt.Errorf("Cannot register space %q: %w", spaceName, err)
 		}
 
-		// Prepare the storage.
-		if err := base.Storage.EnsureExists(prefix); err != nil {
-			return fmt.Errorf("Cannot create storage container %q: %w", prefix, err)
+		if initStorage {
+			// Prepare the storage.
+			if err := base.Storage.EnsureExists(prefix); err != nil {
+				return fmt.Errorf("Cannot create storage container %q: %w", prefix, err)
+			}
 		}
 	}
 

--- a/export/import.go
+++ b/export/import.go
@@ -79,7 +79,7 @@ func cleanCouch() error {
 		}
 	}
 
-	if err := config.PrepareSpaces(); err != nil {
+	if err := config.PrepareSpaces(true); err != nil {
 		return err
 	}
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -548,7 +548,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := config.PrepareSpaces(); err != nil {
+	if err := config.PrepareSpaces(true); err != nil {
 		fmt.Println("Cannot prepare the spaces:", err)
 		os.Exit(1)
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -167,7 +167,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := config.PrepareSpaces(); err != nil {
+	if err := config.PrepareSpaces(true); err != nil {
 		fmt.Println("Cannot prepare the spaces:", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
`PrepareSpaces` ensure storage containers are created for each space. This is required when modifying any app or space but is an unneeded operation when listing apps from couchdb alone.

This extra step add a 6-7 seconds overhead on ls-apps cli command.

This PR skip storage initialization for `ls-apps` command and adds a 3.5x gain on ls-apps command