### PR TITLE
Add a show-virtual-space command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,7 @@ func Root() *cobra.Command {
 	rootCmd.AddCommand(rmAppVersionCmd)
 	rootCmd.AddCommand(lsSpaceCmd)
 	rootCmd.AddCommand(rmSpaceCmd)
+	rootCmd.AddCommand(showVirtualSpaceCmd)
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(importCmd)
 	rootCmd.AddCommand(oldVersionsCmd)

--- a/cmd/space.go
+++ b/cmd/space.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -76,6 +77,31 @@ var lsSpaceCmd = &cobra.Command{
 			}
 		}
 
+		return nil
+	},
+}
+
+var showVirtualSpaceCmd = &cobra.Command{
+	Use:     "show-virtual-space <space>",
+	Short:   `Show virtual space config`,
+	Long:    `Show configuration details for a virtual space`,
+	PreRunE: prepareRegistry,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return cmd.Usage()
+		}
+		spaceName := args[0]
+
+		vSpace, err := config.GetVirtualSpace(spaceName)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.MarshalIndent(vSpace, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
 		return nil
 	},
 }

--- a/config/services.go
+++ b/config/services.go
@@ -323,6 +323,21 @@ func GetVirtualSpaces() []string {
 	return getVspaceKeys(viper.GetStringMap("virtual_spaces"))
 }
 
+func GetVirtualSpace(spaceName string) (*base.VirtualSpace, error) {
+	if !IsVirtualSpace(spaceName) {
+		return nil, fmt.Errorf("%q is not a configured virtual space.", spaceName)
+	}
+
+	virtuals, err := getVirtualSpaces()
+	if err != nil {
+		return nil, err
+	}
+
+	sp := virtuals[spaceName]
+
+	return &sp, nil
+}
+
 // PrepareSpaces makes sure that the CouchDB databases and Swift containers for
 // the spaces exist and have their index/views.
 func PrepareSpaces(initStorage bool) error {


### PR DESCRIPTION
This PR adds a `show-virtual-space` command to print a virtual space configuration in json format