### PR TITLE
Fix duplicate pending versions

### DIFF
--- a/web/versions.go
+++ b/web/versions.go
@@ -121,7 +121,7 @@ func getPendingVersions(c echo.Context) (err error) {
 	}
 
 	slugFilter := c.QueryParam("filter[slug]")
-	filteredVersions := versions[:]
+	filteredVersions := make([]*registry.Version, 0)
 	for _, version := range versions {
 		if slugFilter == "" || version.Slug == slugFilter {
 			cleanVersion(version)


### PR DESCRIPTION
When requesting pnding versions through `/pending` endpoint, pending versions are duplicated

This PR fixes that behavior, as well as a bug when filtering by slug showing a concatenated list of all pending versions and filtered pending versions