### PR TITLE
Fix filtering pending versions by editor

### DIFF
--- a/web/versions.go
+++ b/web/versions.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/cozy/cozy-apps-registry/base"
 	"github.com/cozy/cozy-apps-registry/errshttp"
@@ -123,7 +124,7 @@ func getPendingVersions(c echo.Context) (err error) {
 	slugFilter := c.QueryParam("filter[slug]")
 	filteredVersions := versions[:]
 	for _, version := range versions {
-		if slugFilter == "" || version.Slug == slugFilter {
+		if (slugFilter == "" || version.Slug == slugFilter) && (editorName == "" || strings.EqualFold(version.Editor, editorName)) {
 			cleanVersion(version)
 			filteredVersions = append(filteredVersions, version)
 		}


### PR DESCRIPTION
When requesting pending versions through `/pending` endpoint and giving an editor for filtering, pending versions in response are not filtered by editor. Instead, all pending versions are currently retrieved whatever their editor is.

This PR fixes that behavior by effectively filtering pending versions by editor.