### PR TITLE
Fix token validation to list and approve pending versions

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -91,6 +91,23 @@ func checkPermissions(c echo.Context, editorName string, appName string, master 
 	return editor, nil
 }
 
+func checkEditorMasterPermissions(c echo.Context, editorName string) error {
+	token, err := extractAuthHeader(c)
+	if err != nil {
+		return err
+	}
+
+	editor, err := auth.Editors.GetEditor(editorName)
+	if err != nil {
+		return errshttp.NewError(http.StatusUnauthorized, "Could not find editor: %s", editorName)
+	}
+
+	if !editor.VerifyMasterToken(base.SessionSecret, token) {
+		return errshttp.NewError(http.StatusUnauthorized, "Token could not be verified")
+	}
+	return nil
+}
+
 func extractAuthHeader(c echo.Context) ([]byte, error) {
 	authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
 	if !strings.HasPrefix(authHeader, authTokenScheme) {


### PR DESCRIPTION
- When listing pending versions, all master editor tokens are considered valid regardless of its editor and can list pending version for all editors.
- When validating pending versions, all master editor tokens are considered valid despite only cozy tokens should allow validating pending versions
- Since fixing editor filtering in #388, it is not possible to list pending version in a space regardless of their editor. Cozy master tokens should allow listing all pending versions regardless of their editor if required.

This MR adresses all these problems.