### PR TITLE
Allow to get pending versions for all editors at once

### DIFF
--- a/web/versions.go
+++ b/web/versions.go
@@ -111,7 +111,12 @@ func getPendingVersions(c echo.Context) (err error) {
 	}
 
 	editorName := c.QueryParam("editor")
-	_, err = checkPermissions(c, editorName, "", true /* = master */)
+
+	tokenEditor := editorName
+	if tokenEditor == "" {
+		tokenEditor = "cozy"
+	}
+	_, err = checkPermissions(c, tokenEditor, "", true /* = master */)
 	if err != nil {
 		return errshttp.NewError(http.StatusUnauthorized, err.Error())
 	}


### PR DESCRIPTION
Since fixing editor filtering in #388, it is not possible anymore to list pending versions in a space regardless of their editor. 

This PR makes editor optional in cas you don't want to filter pending versions in a space by editor 