### PR TITLE
Add endpoint to delete pending version

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -464,6 +464,20 @@ func ApprovePendingVersion(c *space.Space, pending *Version, app *App) (*Version
 	return release, nil
 }
 
+func DeletePendingVersion(c *space.Space, version *Version, app *App) error {
+	// Delete attachments (swift or couchdb)
+	err := version.RemoveAllAttachments(c)
+	if err != nil {
+		return err
+	}
+
+	// Removing the CouchDB document
+	db := c.PendingVersDB()
+	_, err = db.Delete(context.Background(), version.ID, version.Rev)
+
+	return err
+}
+
 func downloadRequest(rawURL string, shasum string) (reader *bytes.Reader, contentType string, err error) {
 	url, err := url.Parse(rawURL)
 	if err != nil {

--- a/web/router.go
+++ b/web/router.go
@@ -379,6 +379,7 @@ func Router() *echo.Echo {
 		g.HEAD("/pending", getPendingVersions, jsonEndpoint, middleware.Gzip())
 		g.GET("/pending", getPendingVersions, jsonEndpoint, middleware.Gzip())
 		g.PUT("/pending/:app/:version/approval", approvePendingVersion, middleware.Gzip())
+		g.DELETE("/pending/:app/:version", deletePendingVersion, middleware.Gzip())
 
 		g.GET("/maintenance", getMaintenanceApps, jsonEndpoint, middleware.Gzip())
 		g.PUT("/maintenance/:app/activate", activateMaintenanceApp, jsonEndpoint, middleware.Gzip())


### PR DESCRIPTION
This PR adds an endpoint to delete a pending version.

a master token is required to call this endpoint.