### PR TITLE
Allow to delete pending version from missing app

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -464,7 +464,7 @@ func ApprovePendingVersion(c *space.Space, pending *Version, app *App) (*Version
 	return release, nil
 }
 
-func DeletePendingVersion(c *space.Space, version *Version, app *App) error {
+func DeletePendingVersion(c *space.Space, version *Version) error {
 	// Delete attachments (swift or couchdb)
 	err := version.RemoveAllAttachments(c)
 	if err != nil {

--- a/web/versions.go
+++ b/web/versions.go
@@ -197,10 +197,6 @@ func deletePendingVersion(c echo.Context) (err error) {
 	if appSlug == "" {
 		return errshttp.NewError(http.StatusNotFound, "App is missing in the URL")
 	}
-	app, err := registry.FindApp(nil, getSpace(c), appSlug, registry.Stable)
-	if err != nil {
-		return err
-	}
 
 	ver := stripVersion(c.Param("version"))
 	if ver == "" {
@@ -211,7 +207,7 @@ func deletePendingVersion(c echo.Context) (err error) {
 		return err
 	}
 
-	if err = registry.DeletePendingVersion(getSpace(c), version, app); err != nil {
+	if err = registry.DeletePendingVersion(getSpace(c), version); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When deleting a pending version for an app that doesn't exist anymore, we get a failure.

This PR let you delete a pending version even if the app it refers to doesn't exist anymore.