### PR TITLE
Remove pending versions when deleting an application

### DIFF
--- a/registry/finders.go
+++ b/registry/finders.go
@@ -640,6 +640,24 @@ func GetPendingVersions(c *space.Space) ([]*Version, error) {
 	return versions, nil
 }
 
+func GetAppPengindVersions(c *space.Space, appSlug string) ([]*Version, error) {
+	versions := make([]*Version, 0)
+	pendingVersions, err := GetPendingVersions(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter by appslug
+	// We could have requested CouchDB with a filter but as we have no index on that table and pending versions number
+	// should be kept low, there souldn't be a performance problem.
+	for _, v := range pendingVersions {
+		if v.Slug == appSlug {
+			versions = append(versions, v)
+		}
+	}
+	return versions, nil
+}
+
 // GetAppChannelVersions returns the versions list of an app channel
 func GetAppChannelVersions(c *space.Space, appSlug string, channel Channel) ([]*Version, error) {
 	var versions []string

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1156,7 +1156,9 @@ func RemoveAppFromSpace(s *space.Space, appSlug string) error {
 	}
 
 	// Then remove all live versions
-	app.Versions, err = FindAppVersionsCacheMiss(s, appSlug, Dev, Concatenated)
+	// NotConcatenated here to avoid trying to delete a stable version 3 times
+	// (one for stable, one for beta and one for dev channel)
+	app.Versions, err = FindAppVersionsCacheMiss(s, appSlug, Dev, NotConcatenated)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR add pending version removal when deleting an application from a space.

It also fixes a bug where removing an application from a space resulted in multiple attemps to delete the same version because sable versions are in dev, beta and stable channels and beta versions are in dev and beta channels.