### PR TITLE
Fix lists in Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Example:
 ##### Categories and Data types
 
 Categories are slugs from the following list:
+
 * `energy`
 * `insurance`
 * `isp`
@@ -457,6 +458,7 @@ Categories are slugs from the following list:
 * `social`
 
 Data types are slugs from the following list:
+
 * `activity`
 * `appointment`
 * `bankTransactions`


### PR DESCRIPTION
If there is no blank line before, many Markdown parsers will not read the lists correctly, including the one used for the Cozy docs, making the page appear broken (see https://docs.cozy.io/en/cozy-apps-registry/#categories-and-data-types)