### PR TITLE
Warn client when trying to change app type or editor

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -51,6 +51,7 @@ var (
 	ErrAppSlugMismatch   = errshttp.NewError(http.StatusBadRequest, "Application slug does not match the one specified in the body")
 	ErrAppSlugInvalid    = errshttp.NewError(http.StatusBadRequest, "Invalid application slug: should contain only lowercase alphanumeric characters and dashes")
 	ErrAppEditorMismatch = errshttp.NewError(http.StatusBadRequest, "Application can not be updated: editor can not change")
+	ErrAppTypeMismatch   = errshttp.NewError(http.StatusBadRequest, "Application can not be updated: type can not change")
 
 	ErrVersionAlreadyExists = errshttp.NewError(http.StatusConflict, "Version already exists")
 	ErrVersionSlugMismatch  = errshttp.NewError(http.StatusBadRequest, "Version slug does not match the application")
@@ -281,6 +282,13 @@ func ModifyApp(c *space.Space, appSlug string, opts AppOptions) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	if opts.Editor != "" && opts.Editor != app.Editor {
+		return nil, ErrAppEditorMismatch
+	}
+	if opts.Type != "" && opts.Type != app.Type {
+		return nil, ErrAppTypeMismatch
+	}
+
 	if opts.DataUsageCommitment != nil {
 		app.DataUsageCommitment = *opts.DataUsageCommitment
 	}


### PR DESCRIPTION
When trying to change an app editor or type with the `PATCH /:space/registry/:app` route, the api returns that everything has been done normally (200) but has in fact not changed type nor editor.

There is a `ErrAppEditorMismatch` error in the code that show that previous developers have chosen to forbid application editor change but this error is not used anywhere in the registry code.

This pull request explicitly forbid trying to change app's editor or type and returns corresponding error to the client.